### PR TITLE
Fix some issues with community addons

### DIFF
--- a/src/multiaddonmanager.cpp
+++ b/src/multiaddonmanager.cpp
@@ -960,7 +960,11 @@ void FASTCALL Hook_SetPendingHostStateRequest(CHostStateMgr* pMgrDoNotUse, CHost
 	
 	if (!pRequest->m_pKV)
 	{
-		g_MultiAddonManager.ClearCurrentWorkshopMap();
+		// When loading an official community map, the KV is empty, but the addon is set regardless.
+		if (pRequest->m_LoopModeType == "levelload" && !pRequest->m_Addons.IsEmpty())
+			g_MultiAddonManager.SetCurrentWorkshopMap(pRequest->m_Addons.Get());
+		else
+			g_MultiAddonManager.ClearCurrentWorkshopMap();
 	}
 	else if (V_stricmp(pRequest->m_pKV->GetName(), "ChangeLevel"))
 	{


### PR DESCRIPTION
The PR makes it so the plugin is aware of community addons, but it doesn't seem to be fool proof:

- Still have random client crashes with de_dogtown every once in a while, but the stack trace points towards nvidia driver dll so it might be a me problem only.
- de_brewery always crashes the server with or without metamod+plugin.