### PR TITLE
Migrate to build containers & start SteamRT4 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - '*'
     branches:
-      - main
+      - '*'
     paths-ignore:
     - LICENSE
     - README.md
@@ -16,66 +16,67 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: ${{ matrix.name }} Build
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
         include:
           - os: windows-latest
+            name: Windows
           - os: ubuntu-latest
-            container: registry.gitlab.steamos.cloud/steamrt/sniper/sdk
+            name: SteamRT3
+            container: ghcr.io/source2ze/build-containers:steamrt3
+          - os: ubuntu-latest
+            name: SteamRT4
+            container: ghcr.io/source2ze/build-containers:steamrt4
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: MultiAddonManager
           submodules: recursive
           fetch-depth: 0
 
       - name: Checkout Metamod
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: alliedmodders/metamod-source
           ref: master
           path: mmsource-2.0
           submodules: recursive
-          
+
       - name: Checkout HL2SDK
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: alliedmodders/hl2sdk
           ref: cs2
           path: hl2sdk-cs2
 
       - name: Checkout AMBuild
-        uses: actions/checkout@v4
+        if: matrix.os == 'windows-latest'
+        uses: actions/checkout@v7
         with:
           repository: alliedmodders/ambuild
           path: ambuild
 
       - name: Install AMBuild
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" == "Windows" ]; then
-            pip install setuptools
-          fi
-          cd ambuild && python setup.py install && cd ..
+        if: matrix.os == 'windows-latest'
+        run: pip install setuptools && cd ambuild && python setup.py install && cd ..
 
       - name: Build
         working-directory: MultiAddonManager
         shell: bash
         run: |
           mkdir build && cd build
-          python ../configure.py --enable-optimize --symbol-files --sdks cs2
+          python ../configure.py --enable-optimize --sdks cs2
           ambuild
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: ${{ runner.os }}
+          name: ${{ matrix.name }}
           path: MultiAddonManager/build/package
 
   release:
@@ -86,15 +87,20 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       - name: Package
         run: |
           version=`echo $GITHUB_REF | sed "s/refs\/tags\///"`
           ls -Rall
-          if [ -d "./Linux/" ]; then
-            cd ./Linux/
-            tar -czf ../${{ github.event.repository.name }}-${version}-linux.tar.gz *
+          if [ -d "./SteamRT3/" ]; then
+            cd ./SteamRT3/
+            tar -czf ../${{ github.event.repository.name }}-${version}-steamrt3.tar.gz *
+            cd -
+          fi
+          if [ -d "./SteamRT4/" ]; then
+            cd ./SteamRT4/
+            tar -czf ../${{ github.event.repository.name }}-${version}-steamrt4.tar.gz *
             cd -
           fi
           if [ -d "./Windows/" ]; then


### PR DESCRIPTION
Brings several benefits:
- Bumps clang version from 11 to 22, without having to reinstall each CI run
- AMBuild is installed in these containers, so we don't have to reinstall each CI run anymore
- Broadens Linux support to SteamRT4, which will be helpful to people who want to run that environment, or even people who try running the plugin on other unsupported distros that aren't compatible with SteamRT3 builds (#44, #71)
- Reduces dependency on Valve's GitLab instance, which has seen temporary downtime in the past, whereas Actions & GHCR are both GitHub infrastructure